### PR TITLE
Add 'Add task' button to Kanban column headers

### DIFF
--- a/kanban-board/src/components/kanban-board.tsx
+++ b/kanban-board/src/components/kanban-board.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { DragDropContext, DropResult } from '@hello-pangea/dnd'
-import { KanbanBoard as KanbanBoardType, Task, DEFAULT_COLUMNS } from '@/types/kanban'
+import { KanbanBoard as KanbanBoardType, Task, TaskStatus, DEFAULT_COLUMNS } from '@/types/kanban'
 import { KanbanColumn } from './kanban-column'
 import { TaskDialog } from './task-dialog'
 import { Button } from './ui/button'
@@ -87,6 +87,7 @@ const INITIAL_BOARD: KanbanBoardType = {
 export function KanbanBoard() {
   const [board, setBoard] = useState<KanbanBoardType>(INITIAL_BOARD)
   const [isTaskDialogOpen, setIsTaskDialogOpen] = useState(false)
+  const [selectedColumnId, setSelectedColumnId] = useState<string | null>(null)
 
   useEffect(() => {
     const savedBoard = localStorage.getItem('kanban-board')
@@ -199,10 +200,15 @@ export function KanbanBoard() {
       },
       columns: prev.columns.map(col =>
         col.id === taskData.status
-          ? { ...col, taskIds: [...col.taskIds, newTask.id] }
+          ? { ...col, taskIds: [newTask.id, ...col.taskIds] }
           : col
       )
     }))
+  }
+
+  const handleAddTaskToColumn = (columnId: string) => {
+    setSelectedColumnId(columnId)
+    setIsTaskDialogOpen(true)
   }
 
   return (
@@ -233,6 +239,7 @@ export function KanbanBoard() {
                 key={column.id}
                 column={column}
                 tasks={column.taskIds.map(taskId => board.tasks[taskId])}
+                onAddTask={handleAddTaskToColumn}
               />
             ))}
           </div>
@@ -240,8 +247,12 @@ export function KanbanBoard() {
 
         <TaskDialog
           open={isTaskDialogOpen}
-          onOpenChange={setIsTaskDialogOpen}
+          onOpenChange={(open) => {
+            setIsTaskDialogOpen(open)
+            if (!open) setSelectedColumnId(null)
+          }}
           onSave={handleCreateTask}
+          initialStatus={selectedColumnId as TaskStatus || 'todo'}
         />
       </div>
     </div>

--- a/kanban-board/src/components/kanban-column.tsx
+++ b/kanban-board/src/components/kanban-column.tsx
@@ -5,14 +5,17 @@ import { Column, Task } from '@/types/kanban'
 import { TaskCard } from './task-card'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { Badge } from './ui/badge'
+import { Button } from './ui/button'
+import { Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface KanbanColumnProps {
   column: Column
   tasks: Task[]
+  onAddTask: (columnId: string) => void
 }
 
-export function KanbanColumn({ column, tasks }: KanbanColumnProps) {
+export function KanbanColumn({ column, tasks, onAddTask }: KanbanColumnProps) {
   return (
     <div className="flex-shrink-0 w-80 animate-slide-in-up">
       <Card className={cn(
@@ -31,6 +34,15 @@ export function KanbanColumn({ column, tasks }: KanbanColumnProps) {
               {tasks.length}
             </Badge>
           </CardTitle>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="w-full mt-2 border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 hover:bg-white/50 dark:hover:bg-slate-700/50 text-slate-600 dark:text-slate-400"
+            onClick={() => onAddTask(column.id)}
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Add task
+          </Button>
         </CardHeader>
         <CardContent className="pt-0">
           <Droppable droppableId={column.id}>


### PR DESCRIPTION
## Summary
- Adds an "Add task" button at the top of each Kanban column
- Clicking the button opens the task creation dialog pre-filled with the column's status
- New tasks are added to the top of the column's task list

## Changes

### KanbanBoard Component
- Introduced `selectedColumnId` state to track which column's add button was clicked
- Added `handleAddTaskToColumn` to open the task dialog with the selected column
- Updated `TaskDialog` to accept `initialStatus` prop for pre-selecting task status
- Modified task creation to prepend new tasks to the column's task list

### KanbanColumn Component
- Added `onAddTask` prop to handle add task button clicks
- Rendered a new "Add task" button below the column title with a plus icon
- Styled the button with dashed border and hover effects for better UX

## Test plan
- [x] Verify "Add task" button appears on each column header
- [x] Click button opens task dialog with correct initial status
- [x] Create task adds it to the top of the selected column
- [x] Closing task dialog resets selected column state

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b343e253-3662-401b-ade1-f9bf51704048