### PR TITLE
Add 'Copy as Markdown' feature to TaskCard component

### DIFF
--- a/kanban-board/src/components/task-card.tsx
+++ b/kanban-board/src/components/task-card.tsx
@@ -12,7 +12,8 @@ import {
   Zap,
   FileText,
   Wrench,
-  Book
+  Book,
+  Copy
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { 
@@ -53,9 +54,63 @@ function formatDate(date: Date): string {
   }).format(date)
 }
 
+function formatTaskAsMarkdown(task: Task): string {
+  const lines: string[] = []
+  
+  lines.push(`# ${task.title}`)
+  lines.push('')
+  
+  if (task.description) {
+    lines.push(task.description)
+    lines.push('')
+  }
+  
+  lines.push('## Details')
+  lines.push('')
+  lines.push(`- **Type**: ${task.type}`)
+  lines.push(`- **Priority**: ${task.priority}`)
+  lines.push(`- **Status**: ${task.status}`)
+  
+  if (task.assignee) {
+    lines.push(`- **Assignee**: ${task.assignee}`)
+  }
+  
+  if (task.dueDate) {
+    lines.push(`- **Due Date**: ${task.dueDate.toLocaleDateString()}`)
+  }
+  
+  if (task.tags && task.tags.length > 0) {
+    lines.push(`- **Tags**: ${task.tags.join(', ')}`)
+  }
+  
+  lines.push('')
+  lines.push(`- **Created**: ${task.createdAt.toLocaleDateString()}`)
+  lines.push(`- **Updated**: ${task.updatedAt.toLocaleDateString()}`)
+  
+  return lines.join('\n')
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    document.body.appendChild(textArea)
+    textArea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textArea)
+  }
+}
+
 export function TaskCard({ task, index }: TaskCardProps) {
   const TypeIcon = TYPE_ICONS[task.type]
   const isOverdue = task.dueDate && task.dueDate < new Date() && task.status !== 'done'
+  
+  const handleCopyAsMarkdown = async () => {
+    const markdown = formatTaskAsMarkdown(task)
+    await copyToClipboard(markdown)
+  }
 
   return (
     <Draggable draggableId={task.id} index={index}>
@@ -102,6 +157,10 @@ export function TaskCard({ task, index }: TaskCardProps) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={handleCopyAsMarkdown}>
+                    <Copy className="w-4 h-4 mr-2" />
+                    Copy as Markdown
+                  </DropdownMenuItem>
                   <DropdownMenuItem>Edit</DropdownMenuItem>
                   <DropdownMenuItem>Duplicate</DropdownMenuItem>
                   <DropdownMenuItem className="text-red-600">Delete</DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Introduces a new feature to copy task details as formatted Markdown text
- Adds a "Copy as Markdown" option in the task card dropdown menu
- Implements clipboard copy functionality with fallback for unsupported browsers

## Changes

### Core Functionality
- **Markdown Formatting**: Added `formatTaskAsMarkdown` function to convert task details into a structured Markdown string
- **Clipboard Copy**: Created `copyToClipboard` function to copy text to the clipboard with a fallback using a temporary textarea
- **Copy Handler**: Added `handleCopyAsMarkdown` event handler to trigger Markdown formatting and copying

### UI Updates
- **Dropdown Menu**: Added a new menu item with a copy icon labeled "Copy as Markdown" in the task card's dropdown menu

## Test plan
- [x] Verify that clicking "Copy as Markdown" copies the task details in Markdown format to the clipboard
- [x] Confirm fallback copy method works in browsers without clipboard API support
- [x] Check that all relevant task fields (title, description, type, priority, status, assignee, due date, tags, created and updated dates) are included and correctly formatted in the Markdown output
- [x] Ensure UI integration does not affect existing dropdown menu items and functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/225a61fb-9605-4a76-9513-8b9437c75b07