### PR TITLE
Make Kanban board responsive with grid layout and remove horizontal scroll

### DIFF
--- a/kanban-board/src/components/kanban-board.tsx
+++ b/kanban-board/src/components/kanban-board.tsx
@@ -232,7 +232,7 @@ export function KanbanBoard() {
       </div>
 
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="flex gap-6 overflow-x-auto flex-1 p-6 pt-0">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 flex-1 p-6 pt-0 overflow-hidden">
           {board.columns.map(column => (
             <KanbanColumn
               key={column.id}

--- a/kanban-board/src/components/kanban-column.tsx
+++ b/kanban-board/src/components/kanban-column.tsx
@@ -17,7 +17,7 @@ interface KanbanColumnProps {
 
 export function KanbanColumn({ column, tasks, onAddTask }: KanbanColumnProps) {
   return (
-    <div className="flex-shrink-0 w-80 h-full animate-slide-in-up">
+    <div className="h-full animate-slide-in-up min-w-0">
       <Card className={cn(
         "h-full border-0 shadow-sm hover:shadow-md transition-all duration-300 flex flex-col",
         column.color


### PR DESCRIPTION
## Summary
- Replaced horizontal scrollable flex layout with a responsive grid layout for the Kanban board columns
- Updated KanbanColumn component styling to support flexible width and prevent shrinking

## Changes

### KanbanBoard Component
- Changed container div from `flex` with `overflow-x-auto` to a CSS grid with responsive column counts:
  - 1 column on smallest screens
  - 2 columns on small screens
  - 3 columns on medium screens
  - 4 columns on large screens
  - 5 columns on extra-large screens
- Removed horizontal scrolling by setting `overflow-hidden` on the container

### KanbanColumn Component
- Updated column container div to remove fixed width and flex-shrink
- Added `min-w-0` to allow proper shrinking within grid layout

## Test plan
- [x] Verify Kanban board columns display in a grid layout on various screen sizes
- [x] Confirm no horizontal scrollbar appears on the board
- [x] Check that column cards animate and render correctly within the new layout
- [x] Test drag-and-drop functionality remains intact after layout change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c5d212a4-d0f9-4bb9-8cd1-e72033a2ada2