### PR TITLE
Implement theme modes with toggle in Kanban board layout

### DIFF
--- a/kanban-board/src/app/layout.tsx
+++ b/kanban-board/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
+import { ThemeProvider } from "@/contexts/theme-context";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,20 +31,23 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset>
-            <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-              <SidebarTrigger className="-ml-1" />
-              <div className="ml-auto">
-                <h1 className="text-lg font-semibold">Terragon Labs</h1>
-              </div>
-            </header>
-            <main className="flex flex-1 flex-col gap-4 p-4">
-              {children}
-            </main>
-          </SidebarInset>
-        </SidebarProvider>
+        <ThemeProvider>
+          <SidebarProvider>
+            <AppSidebar />
+            <SidebarInset>
+              <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+                <SidebarTrigger className="-ml-1" />
+                <div className="ml-auto flex items-center gap-4">
+                  <h1 className="text-lg font-semibold">Terragon Labs</h1>
+                  <ThemeToggle />
+                </div>
+              </header>
+              <main className="flex flex-1 flex-col gap-4 p-4">
+                {children}
+              </main>
+            </SidebarInset>
+          </SidebarProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/kanban-board/src/components/theme-toggle.tsx
+++ b/kanban-board/src/components/theme-toggle.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Moon, Sun, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useTheme } from "@/contexts/theme-context"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" className="h-9 w-9">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")} className="cursor-pointer">
+          <Sun className="mr-2 h-4 w-4" />
+          <span>Light</span>
+          {theme === "light" && <span className="ml-auto">✓</span>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")} className="cursor-pointer">
+          <Moon className="mr-2 h-4 w-4" />
+          <span>Dark</span>
+          {theme === "dark" && <span className="ml-auto">✓</span>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")} className="cursor-pointer">
+          <Monitor className="mr-2 h-4 w-4" />
+          <span>System</span>
+          {theme === "system" && <span className="ml-auto">✓</span>}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/kanban-board/src/contexts/theme-context.tsx
+++ b/kanban-board/src/contexts/theme-context.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react"
+
+type Theme = "light" | "dark" | "system"
+
+interface ThemeContextType {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  actualTheme: "light" | "dark"
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return context
+}
+
+interface ThemeProviderProps {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>("system")
+  const [actualTheme, setActualTheme] = useState<"light" | "dark">("light")
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme") as Theme
+    if (savedTheme && ["light", "dark", "system"].includes(savedTheme)) {
+      setTheme(savedTheme)
+    }
+  }, [])
+
+  useEffect(() => {
+    const updateActualTheme = () => {
+      let newActualTheme: "light" | "dark"
+      
+      if (theme === "system") {
+        newActualTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+      } else {
+        newActualTheme = theme
+      }
+      
+      setActualTheme(newActualTheme)
+      
+      if (newActualTheme === "dark") {
+        document.documentElement.classList.add("dark")
+      } else {
+        document.documentElement.classList.remove("dark")
+      }
+    }
+
+    updateActualTheme()
+
+    if (theme === "system") {
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+      mediaQuery.addEventListener("change", updateActualTheme)
+      return () => mediaQuery.removeEventListener("change", updateActualTheme)
+    }
+  }, [theme])
+
+  const handleSetTheme = (newTheme: Theme) => {
+    setTheme(newTheme)
+    localStorage.setItem("theme", newTheme)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme: handleSetTheme, actualTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds theme mode support (light, dark, system) to the Kanban board application
- Introduces a ThemeProvider context to manage theme state and persistence
- Adds a ThemeToggle component for users to switch between theme modes
- Integrates theme toggle UI into the app header alongside the sidebar

## Changes

### Theme Context
- Created `ThemeProvider` context to handle theme state, including system preference detection
- Stores user theme preference in localStorage for persistence
- Dynamically applies `dark` class to document root based on active theme

### UI Components
- Added `ThemeToggle` dropdown menu component with options for Light, Dark, and System themes
- Displays current theme with icons and checkmarks

### Layout Integration
- Wrapped the app layout with `ThemeProvider` to provide theme context
- Added `ThemeToggle` button to the header next to the app title and sidebar trigger

## Test plan
- [x] Verify theme preference is loaded from localStorage on app start
- [x] Test toggling between Light, Dark, and System themes updates UI accordingly
- [x] Confirm theme changes persist across page reloads
- [x] Check that system theme changes (OS dark mode) are respected when in System mode
- [x] Ensure the theme toggle button is visible and functional in the header

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f72596fc-fa90-4b3c-85f0-6a1bd39dbb25